### PR TITLE
Upload models on cloud storage

### DIFF
--- a/autoafids/config/snakebids.yml
+++ b/autoafids/config/snakebids.yml
@@ -85,10 +85,9 @@ parse_args:
       nargs: +
 
   --model:
-      help: 'Path to the machine learning model to apply.'
+      help: 'Type of machine learning model to apply.'
+      default: 'default'
       required: false
-      default: '../../Downloads/model-combined.afidsmodel'
-      type: Path
 
 #--- workflow specific configuration ---
 
@@ -105,4 +104,5 @@ singularity:
 
 # It will be downloaded to ~/.cache/autoafids
 resource_urls:
-  cnn_model: 'zenodo'
+  default: 'zenodo.org/records/14284289/files/model-combined.afidsmodel'
+  synthSR: 'zenodo.org/records/14284290/files/model-combined.afidsmodel' # dummy file which doesn't exist

--- a/autoafids/workflow/Snakefile
+++ b/autoafids/workflow/Snakefile
@@ -1,4 +1,5 @@
 from snakebids import bids, generate_inputs, get_wildcard_constraints
+from appdirs import AppDirs
 
 configfile: 'snakebids.yml'
 
@@ -15,6 +16,16 @@ inputs = generate_inputs(
 wildcard_constraints:
     **get_wildcard_constraints(config["pybids_inputs"]),
 
+def get_download_dir():
+    if "AUTOAFIDS_CACHE_DIR" in os.environ.keys():
+        download_dir = os.environ["AUTOAFIDS_CACHE_DIR"]
+    else:
+        # create local download dir if it doesn't exist
+        dirs = AppDirs("autoafids", "jclauneurolab")
+        download_dir = dirs.user_cache_dir
+    return download_dir
+
+download_dir = get_download_dir()
 # ---- begin preproc profile pathways --------------------------------------------
 
 processing_steps = {
@@ -172,26 +183,7 @@ rule preprocessing_result:
         samp = inputs["t1w"].expand(rules.resample_im.output.resam_im),
         mni = inputs["t1w"].expand(rules.mni2subfids.output.fcsv_new),
 
-rule gen_fcsv:
-    input:
-        t1w=rules.preprocessing_result.input.samp, 
-        model=config["model"],
-        prior=rules.preprocessing_result.input.mni,
-    output:
-        fcsv=bids(
-            root=str(Path(config["output_dir"]) / "afids-cnn"),
-            desc="afidscnn",
-            suffix="afids.fcsv",
-            **inputs["t1w"].wildcards
-        ),
-    log:
-        bids(
-            root="logs",
-            suffix="landmark.log",
-            **inputs["t1w"].wildcards
-        ),
-    shell:
-        'auto_afids_cnn_apply {input.t1w} {input.model} {output.fcsv} {input.prior}'
+include: "rules/cnn.smk"
 
 rule all:
     input:

--- a/autoafids/workflow/rules/cnn.smk
+++ b/autoafids/workflow/rules/cnn.smk
@@ -1,0 +1,40 @@
+# populate the AUTOAFIDS_CACHE_DIR folder as needed
+
+def get_model():
+    model_name = config["model"]
+
+    local_model = config["resource_urls"].get(model_name, None)
+    if local_model == None:
+        print(f"ERROR: {model_name} does not exist.")
+
+    return (Path(download_dir)/ "model" / Path(local_model).name).absolute()
+
+rule download_cnn_model:
+    params:
+        url=config["resource_urls"][config["model"]],
+        model_dir=Path(download_dir) / "model"
+    output:
+        model=get_model()
+    shell:
+        "mkdir -p {params.model_dir} && wget https://{params.url} -O {output}"
+
+rule gen_fcsv:
+    input:
+        t1w=rules.preprocessing_result.input.samp, 
+        model=get_model(),
+        prior=rules.preprocessing_result.input.mni,
+    output:
+        fcsv=bids(
+            root=str(Path(config["output_dir"]) / "afids-cnn"),
+            desc="afidscnn",
+            suffix="afids.fcsv",
+            **inputs["t1w"].wildcards
+        ),
+    log:
+        bids(
+            root="logs",
+            suffix="landmark.log",
+            **inputs["t1w"].wildcards
+        ),
+    shell:
+        'auto_afids_cnn_apply {input.t1w} {input.model} {output.fcsv} {input.prior}'

--- a/poetry.lock
+++ b/poetry.lock
@@ -4289,4 +4289,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <3.12"
-content-hash = "9f41e7584ec051bb6f9e39e2d5b18878087ede3bbe251188e75965d233697d23"
+content-hash = "851a0458d026379a5ab8ad18405bd28404d2c5c41206ac0a632cf2422a14471f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ tensorflow = "^2.12.0"
 tensorflow-io-gcs-filesystem = "^0.31.0"
 pulp = "<2.6.0"
 scikit-image = "^0.19.3"
+appdirs = "^1.4.4"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.7.0"


### PR DESCRIPTION
This PR adds logic to pull machine learning models from cloud storage, i.e., zenodo, and use them to predict Anatomical Fiducials (AFIDs) on input images. As a consequence of this, the inference part of the pipeline has been modularized from the overall workflow. 