### PR TITLE
Add CT modality to Synthsr

### DIFF
--- a/autoafids/config/snakebids.yml
+++ b/autoafids/config/snakebids.yml
@@ -119,7 +119,7 @@ parse_args:
         - T1w
         - T2w
         - FLAIR
-        - CT
+        - ct
 
   --derivatives:
       help: 'Path(s) to a derivatives dataset, for folder(s) that contains multiple

--- a/autoafids/config/snakebids.yml
+++ b/autoafids/config/snakebids.yml
@@ -53,7 +53,7 @@ pybids_inputs:
   
   CT:
     filters:
-      suffix: CT
+      suffix: ct
       extension: .nii.gz
       datatype: anat
     wildcards:

--- a/autoafids/config/snakebids.yml
+++ b/autoafids/config/snakebids.yml
@@ -50,6 +50,18 @@ pybids_inputs:
       - acquisition
       - reconstruction
       - run
+  
+  CT:
+    filters:
+      suffix: CT
+      extension: .nii.gz
+      datatype: anat
+    wildcards:
+      - subject
+      - session
+      - acquisition
+      - reconstruction
+      - run
 
 parse_args:
 #---  core BIDS-app options ---
@@ -101,12 +113,13 @@ parse_args:
       default: '100'  # Default to 1 
     
   --modality: 
-      help: 'Specify the modality to use (e.g., T1w, T2w, or FLAIR).'
+      help: 'Specify the modality to use (e.g., T1w, T2w, FLAIR, or CT).'
       default: 'T1w'
       choices:
         - T1w
         - T2w
         - FLAIR
+        - CT
 
   --derivatives:
       help: 'Path(s) to a derivatives dataset, for folder(s) that contains multiple

--- a/autoafids/workflow/Snakefile
+++ b/autoafids/workflow/Snakefile
@@ -13,7 +13,7 @@ configfile: 'config/snakebids.yml'
 selected_pybids_input = {config['modality']: config['pybids_inputs'][config['modality']]}
 
 # show synthsr warning message if t2w or flair is chosen 
-warn_modalities = ['T2w', 'FLAIR', 'CT']
+warn_modalities = ['T2w', 'FLAIR', 'ct']
 if config['modality'] in warn_modalities:
     warnings.warn(
         f"The AFIDS prediction on a {config['modality']} image is only as accurate as the SynthSR conversion of a {config['modality']} to a T1w image.",
@@ -21,7 +21,7 @@ if config['modality'] in warn_modalities:
     )
 
 # show synthsr warning message for ct modality 
-if config['modality'] == 'CT':
+if config['modality'] == 'ct':
     warnings.warn(
         f"SynthSR does a decent job with CT scans! The only caveat is that the dynamic range of CT is very different to that of MRI, so they need to be clipped to [0, 80] Hounsfield units. This program will do this for CT images, as long as your image volume is in Hounsfield units.",
         UserWarning
@@ -130,7 +130,7 @@ if config['modality'] != "T1w":
             mem_mb=10000
         threads: max(1, workflow.cores // max(1, available_mem_mb // 10000))
         container: config['singularity']['synthsr']
-        params: '--ct' if config['modality'] == "CT" else ''
+        params: '--ct' if config['modality'] == "ct" else ''
         shell: 
             """
             python /app/scripts/predict_command_line.py {input.im} {output.preprocessed_im} --cpu {params} > {log} 2>&1

--- a/autoafids/workflow/Snakefile
+++ b/autoafids/workflow/Snakefile
@@ -13,10 +13,17 @@ configfile: 'config/snakebids.yml'
 selected_pybids_input = {config['modality']: config['pybids_inputs'][config['modality']]}
 
 # show synthsr warning message if t2w or flair is chosen 
-warn_modalities = ['T2w', 'FLAIR']
+warn_modalities = ['T2w', 'FLAIR', 'CT']
 if config['modality'] in warn_modalities:
     warnings.warn(
         f"The AFIDS prediction on a {config['modality']} image is only as accurate as the SynthSR conversion of a {config['modality']} to a T1w image.",
+        UserWarning
+    )
+
+# show synthsr warning message for ct modality 
+if config['modality'] == 'CT':
+    warnings.warn(
+        f"SynthSR does a decent job with CT scans! The only caveat is that the dynamic range of CT is very different to that of MRI, so they need to be clipped to [0, 80] Hounsfield units. This program will do this for CT images, as long as your image volume is in Hounsfield units.",
         UserWarning
     )
 
@@ -123,9 +130,10 @@ if config['modality'] != "T1w":
             mem_mb=10000
         threads: max(1, workflow.cores // max(1, available_mem_mb // 10000))
         container: config['singularity']['synthsr']
+        params: '--ct' if config['modality'] == "CT" else ''
         shell: 
             """
-                python /app/scripts/predict_command_line.py {input.im} {output.preprocessed_im} --cpu > {log} 2>&1
+            python /app/scripts/predict_command_line.py {input.im} {output.preprocessed_im} --cpu {params} > {log} 2>&1
             """
 
 if "n4_bias_correction" in profile_settings and config['modality'] == "T1w":


### PR DESCRIPTION
Some things to think about regarding this feature @ataha24 :

1. From SynthSR documentation: SynthSR does a decent job with CT scans! The only caveat is that the dynamic range of CT is very different to that of MRI, so they need to be clipped to [0, 80] Hounsfield units. You can use the --ct flag to do this, as long as your image volume is in Hounsfield units. If not, you will have to clip to the Hounsfield equivalent yourself (and not use --ct).

Right now I implemented to add the --ct flag to synthsr if the modality is CT, but maybe due to above we add a flag like --ct-non-hounsfield in the autoafids command for if users were to clip there images, because if that case the --ct flag should not be added for synthsr.
 
2. Where should CT files be accessible? I found mixed opinions on CT images with BIDS formatting online so for now I just have it in the anat folder with the other modalities, but I can change this if there is a better alternative. 

for issue: #20 


