### PR TITLE
Solve dependency conflict in conda env

### DIFF
--- a/autoafids/workflow/envs/tensorflow.yaml
+++ b/autoafids/workflow/envs/tensorflow.yaml
@@ -2,7 +2,7 @@
 name: tensorflow
 channels: [conda-forge, defaults]
 dependencies:
-  - python=3.10
+  - python=3.9
   - nibabel
   - pandas
   - scikit-image=0.19.3

--- a/autoafids/workflow/scripts/apply.py
+++ b/autoafids/workflow/scripts/apply.py
@@ -52,7 +52,7 @@ FCSV_TEMPLATE = (
 
 def afids_to_fcsv(
     afid_coords: dict[int, NDArray],
-    fcsv_output: os.PathLike[str] | str,
+    fcsv_output: Union[PathLike, str],
 ) -> None:
     """
     AFIDS to Slicer-compatible .fcsv file.
@@ -327,11 +327,11 @@ def process_distances(
 
 
 def apply_model(
-    img: nib.nifti1.Nifti1Image | nib.nifti1.Nifti1Pair,
+    img: Union[nib.nifti1.Nifti1Image, nib.nifti1.Nifti1Pair],
     fid_label: int,
     model: tf.keras.Model,
     radius: int,
-    prior: PathLike[str] | str,
+    prior: Union[PathLike, str],
 ) -> NDArray:
     """
     Apply model


### PR DESCRIPTION
Downgrade python to 3.9 in tensorflow.yaml and use Union in-place of pipe for declaring variable type.