### PR TITLE
Mackenzie/conda default

### DIFF
--- a/.github/workflows/lint-and-dryrun-testing.yml
+++ b/.github/workflows/lint-and-dryrun-testing.yml
@@ -34,25 +34,27 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: ["quality"]
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
-      - name: Install non-python dependencies
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Miniforge and mamba
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
+          mamba-version: "*"
+          use-mamba: true
+          conda-solver: libmamba
+          auto-activate-base: true
+
+      - name: Install snakebids
         run: |
-          sudo apt-get install -y graphviz-dev
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@v0.3.6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Setup Python environments
-        uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@v0.3.6
-        with:
-          python-version: ${{ matrix.python-version }}
-          install-library: true
+          mamba install snakebids -c bioconda -c conda-forge -y
 
       - name: Setup env for autoafids
         run: |
@@ -60,24 +62,24 @@ jobs:
 
       - name: Test T1w modality
         run: |
-          poetry run autoafids test_data/bids_T1w test_out participant --participant-label 001 -np
+          ./autoafids/run.py test_data/bids_T1w test_out participant --participant-label 001 -np
 
       - name: Test T2w modality
         run: |
-          poetry run autoafids test_data/bids_T2w test_out participant --modality T2w -np -c1
+          ./autoafids/run.py test_data/bids_T2w test_out participant --modality T2w -np -c1
 
       - name: Test CT modality
         run: |
-          poetry run autoafids test_data/bids_ct test_out participant --modality ct -np -c1
+          ./autoafids/run.py test_data/bids_ct test_out participant --modality ct -np -c1
 
       - name: Test stereotaxy feature with T1w modality
         run: |
-          poetry run autoafids test_data/bids_T1w test_out participant --participant-label 001 --stereotaxy STN -np
+          ./autoafids/run.py test_data/bids_T1w test_out participant --participant-label 001 --stereotaxy STN -np
 
       - name: Test stereotaxy feature with T2w modality
         run: |
-          poetry run autoafids test_data/bids_T2w test_out participant --stereotaxy STN --modality T2w -np -c1
+          ./autoafids/run.py test_data/bids_T2w test_out participant --stereotaxy STN --modality T2w -np -c1
 
       - name: Test fidqc feature
         run: |
-          poetry run autoafids test_data/bids_T1w test_out participant --participant-label 001 --fidqc -np
+          ./autoafids/run.py test_data/bids_T1w test_out participant --participant-label 001 --fidqc -np

--- a/.github/workflows/wetrun-testing.yml
+++ b/.github/workflows/wetrun-testing.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           conda activate snakebids-env
           ./autoafids/run.py test_data/bids_wetrun_testing test_out participant \
-            --cores all --force-output --stereotaxy STN --fidqc --use-conda --conda-frontend mamba | tee autoafids_output.log
+            --cores all --force-output --stereotaxy STN --fidqc --conda-frontend mamba | tee autoafids_output.log
 
       - name: Model accuracy check 
         shell: bash -l {0}

--- a/autoafids/run.py
+++ b/autoafids/run.py
@@ -14,12 +14,10 @@ except ImportError:
 if "__file__" not in globals():
     __file__ = "../autoafids/run.py"
 
-
 app = bidsapp.app(
     [
         plugins.SnakemakeBidsApp(Path(__file__).resolve().parent),
         plugins.BidsValidator(),
-        plugins.Version(distribution="autoafids"),
         plugins.CliConfig("parse_args"),
         plugins.ComponentEdit("pybids_inputs"),
     ]

--- a/autoafids/workflow/profiles/default/config.yaml
+++ b/autoafids/workflow/profiles/default/config.yaml
@@ -1,0 +1,1 @@
+use-conda: True

--- a/docs/getting_started/conda.md
+++ b/docs/getting_started/conda.md
@@ -70,7 +70,7 @@ ds002168/
 Running AutoAFIDs:
 
 ```bash
-autoafids ds002168 ds002168_autoafids participant --cores all --use-conda
+autoafids ds002168 ds002168_autoafids participant --cores all
 ```
 
 This should run the full pipeline and place results in a new `ds002168_autoafids/` folder.


### PR DESCRIPTION
- make conda the default so we no longer have to specify `--use-conda` in the command line
- change the dry runs to use conda 
- to address #55 