### PR TITLE
Use conda as a default solver

### DIFF
--- a/autoafids/workflow/profiles/default/config.yaml
+++ b/autoafids/workflow/profiles/default/config.yaml
@@ -1,1 +1,2 @@
 use-conda: True
+conda-frontend: conda


### PR DESCRIPTION
This PR addresses issue #64. Adding conda as the default solver will help circumvent the incompatibility between `mamba` v2 and snakemake.