### PR TITLE
factoring out resampling as synthsr outputs are already resampled

### DIFF
--- a/autoafids/workflow/Snakefile
+++ b/autoafids/workflow/Snakefile
@@ -228,7 +228,7 @@ rule norm_im:
         "scripts/norm_schemes.py"
 
 
-if "resample_im" in profile_settings:
+if "resample_im" in profile_settings and config["modality"] == "T1w":
 
     rule resample_im:
         input:

--- a/autoafids/workflow/rules/cnn.smk
+++ b/autoafids/workflow/rules/cnn.smk
@@ -19,13 +19,23 @@ rule download_cnn_model:
 
 rule gen_fcsv:
     input:
-        t1w=bids(
-            root=work,
-            datatype="resample",
-            desc=chosen_norm_method,
-            res=config["res"],
-            suffix="T1w.nii.gz",
-            **inputs[config["modality"]].wildcards,
+        t1w=lambda wildcards: (
+            bids(
+                root=work,
+                datatype="normalize",
+                desc=chosen_norm_method,
+                suffix="T1w.nii.gz",
+                **inputs[config["modality"]].wildcards
+            )
+            if config["modality"] != "T1w"  # SynthSR used → no resample
+            else bids(
+                root=work,
+                datatype="resample",
+                desc=chosen_norm_method,
+                res=config["res"],
+                suffix="T1w.nii.gz",
+                **inputs[config["modality"]].wildcards
+            )
         ),
         prior=bids(
             root=work,


### PR DESCRIPTION
when we run sythsr on modalities other than T1w, the output is resampled to 1mm isotropic so added logic to skip that step in the same way we skip n4biascorrection 